### PR TITLE
FIX 'numeric'

### DIFF
--- a/includes/api/class-wc-rest-cart-controller.php
+++ b/includes/api/class-wc-rest-cart-controller.php
@@ -155,7 +155,7 @@ class WC_REST_Cart_Controller {
 	public function get_cart( $data = array() ) {
 		$cart = WC()->cart->get_cart();
 
-		if ( $this->get_cart_contents_count( array( 'return' => numeric ) ) <= 0 ) {
+		if ( $this->get_cart_contents_count( array( 'return' => 'numeric' ) ) <= 0 ) {
 			return new WP_REST_Response( __( 'Cart is empty!', 'cart-rest-api-for-woocommerce' ), 200 );
 		}
 


### PR DESCRIPTION
There was an error:
```
[30-May-2018 16:37:16 UTC] PHP Warning:  Use of undefined constant numeric - assumed 'numeric' (this will throw an Error in a future version of PHP) in D:\server72\sites\trendov.ld\wp-content\plugins\cart-rest-api-for-woocommerce\includes\api\class-wc-rest-cart-controller.php on line 158
[30-May-2018 16:37:16 UTC] PHP Stack trace:
[30-May-2018 16:37:16 UTC] PHP   1. {main}() D:\server72\sites\trendov.ld\index.php:0
[30-May-2018 16:37:16 UTC] PHP   2. require() D:\server72\sites\trendov.ld\index.php:17
[30-May-2018 16:37:16 UTC] PHP   3. wp() D:\server72\sites\trendov.ld\wp-blog-header.php:16
[30-May-2018 16:37:16 UTC] PHP   4. WP->main() D:\server72\sites\trendov.ld\wp-includes\functions.php:960
[30-May-2018 16:37:16 UTC] PHP   5. WP->parse_request() D:\server72\sites\trendov.ld\wp-includes\class-wp.php:713
[30-May-2018 16:37:16 UTC] PHP   6. do_action_ref_array() D:\server72\sites\trendov.ld\wp-includes\class-wp.php:373
[30-May-2018 16:37:16 UTC] PHP   7. WP_Hook->do_action() D:\server72\sites\trendov.ld\wp-includes\plugin.php:515
[30-May-2018 16:37:16 UTC] PHP   8. WP_Hook->apply_filters() D:\server72\sites\trendov.ld\wp-includes\class-wp-hook.php:310
[30-May-2018 16:37:16 UTC] PHP   9. rest_api_loaded() D:\server72\sites\trendov.ld\wp-includes\class-wp-hook.php:286
[30-May-2018 16:37:16 UTC] PHP  10. WP_REST_Server->serve_request() D:\server72\sites\trendov.ld\wp-includes\rest-api.php:266
[30-May-2018 16:37:16 UTC] PHP  11. WP_REST_Server->dispatch() D:\server72\sites\trendov.ld\wp-includes\rest-api\class-wp-rest-server.php:321
[30-May-2018 16:37:16 UTC] PHP  12. WC_REST_Cart_Controller->get_cart() D:\server72\sites\trendov.ld\wp-includes\rest-api\class-wp-rest-server.php:936
```

This led to a breakdown of the json response. The debugging mode is enabled accordingly.

Use:
PHP 7.0
WordPress 4.9.6
WooCommerce 3.4.0
Cart REST API for WooCommerce 1.0.3 